### PR TITLE
fixed tests that expected single quotes as table escaping symbols

### DIFF
--- a/src/test/java/com/axibase/tsd/driver/jdbc/connectionString/ExpandTagsTest.java
+++ b/src/test/java/com/axibase/tsd/driver/jdbc/connectionString/ExpandTagsTest.java
@@ -26,7 +26,7 @@ import static util.TestProperties.*;
 @Issue("4291")
 public class ExpandTagsTest extends DriverTestBase {
     private static final String METRIC_WITH_TAGS = "java_method_invoke_average";
-    private static final String[] AVAILABLE_TAGS = {"tags.'host'", "tags.'name'"};
+    private static final String[] AVAILABLE_TAGS = {"tags.\"host\"", "tags.\"name\""};
     private static final String TAGS_COLUMN = "tags";
 
     @Rule

--- a/src/test/java/com/axibase/tsd/driver/jdbc/connectionString/MetaColumnsTest.java
+++ b/src/test/java/com/axibase/tsd/driver/jdbc/connectionString/MetaColumnsTest.java
@@ -75,7 +75,7 @@ public class MetaColumnsTest extends DriverTestBase {
                 "metric.dataType, metric.description, metric.enabled, metric.filter, metric.interpolate, " +
                 "metric.invalidValueAction, metric.label, metric.lastInsertTime, metric.maxValue, metric.minValue, " +
                 "metric.name, metric.persistent, metric.retentionIntervalDays, metric.tags, metric.timePrecision, " +
-                "metric.timeZone, metric.versioning, metric.units FROM '" + TABLE + "' LIMIT 1";
+                "metric.timeZone, metric.versioning, metric.units FROM \"" + TABLE + "\" LIMIT 1";
         metaColumnsTestScenario(connectString, hasItems(META_COLUMNS), expectedRemarks);
     }
 
@@ -83,14 +83,14 @@ public class MetaColumnsTest extends DriverTestBase {
     @DisplayName("Test that meta columns are not exposed in getColumns and table remarks if metaColumns=false")
     public void testMetaColumnsFalse() throws SQLException {
         final String connectString = getConnectStringWithMetaColumnsValue("false");
-        final String expectedRemarks = "SELECT time, datetime, value, text, metric, entity, tags FROM '" + TABLE + "' LIMIT 1";
+        final String expectedRemarks = "SELECT time, datetime, value, text, metric, entity, tags FROM \"" + TABLE + "\" LIMIT 1";
         metaColumnsTestScenario(connectString, not(hasItems(META_COLUMNS)), expectedRemarks);
     }
 
     @Test
     @DisplayName("Test that meta columns are hidden by default")
     public void testMetaColumnsDefault() throws SQLException {
-        final String expectedRemarks = "SELECT time, datetime, value, text, metric, entity, tags FROM '" + TABLE + "' LIMIT 1";
+        final String expectedRemarks = "SELECT time, datetime, value, text, metric, entity, tags FROM \"" + TABLE + "\" LIMIT 1";
         metaColumnsTestScenario(DEFAULT_JDBC_ATSD_URL, not(hasItems(META_COLUMNS)), expectedRemarks);
     }
 


### PR DESCRIPTION
fixes #10 